### PR TITLE
BEL-4757 add azcopy command to docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,12 @@ LABEL "repository"="https://github.com/bacongobbler/azure-blob-storage-upload"
 LABEL "homepage"="https://github.com/bacongobbler/azure-blob-storage-upload"
 LABEL "maintainer"="Matthew Fisher <matt.fisher@microsoft.com>"
 
+RUN wget https://aka.ms/downloadazcopy-v10-linux -O azcopy.tar.gz \
+    && tar -xvf azcopy.tar.gz --strip-components=1 -C /usr/local/bin azcopy_linux_amd64_*/azcopy \
+    && rm azcopy.tar.gz
+
+RUN azcopy --version
+
 ADD entrypoint.sh /entrypoint.sh
 RUN chmod +x entrypoint.sh
 


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/BEL-4757)

## Purpose 
<!-- what/why -->
This pull request includes a change to the `Dockerfile` to add the installation and verification of `azcopy`. 


## Approach 
<!-- how -->
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R11-R16): Added commands to download, extract, and install `azcopy`, and verify its installation by running `azcopy --version`.

